### PR TITLE
add venv stuff to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,9 @@
 .venv/*
 *.ipynb_checkpoints*
 *__pycache__*
+bin/
+lib/
+lib64
+pyvenv.cfg
+share/
+


### PR DESCRIPTION
`git status` shows a lot of untracked files after installing the virtualenv. Add them to the `.gitignore` file