### PR TITLE
Fix typo in session0/complete/session0.ipynb

### DIFF
--- a/session0/complete/session0.ipynb
+++ b/session0/complete/session0.ipynb
@@ -314,9 +314,10 @@
     "b = unhexlify(h)\n",
     "# reverse ([::-1])\n",
     "b_rev = b[::-1]\n",
-    "# convert to hex (hexlify)h_rev = hexlify(b_rev)\n",
+    "# convert to hex (hexlify)\n",
+    "h_rev = hexlify(b_rev)\n",
     "\n",
-    "print(hexlify(b_rev))"
+    "print(h_rev)"
    ]
   }
  ],


### PR DESCRIPTION
There's extra trailing code in a comment in `session0/complete` that does not execute.