### PR TITLE
Fixed typo

### DIFF
--- a/session1/ecc.py
+++ b/session1/ecc.py
@@ -20,7 +20,7 @@ class FieldElement:
         if other is None:
             return True
         return self.num != other.num or self.prime != other.prime
-v
+
     def __repr__(self):
         return 'FieldElement_{}({})'.format(self.prime, self.num)
 


### PR DESCRIPTION
Removed an apparent spurious 'v' that was added in the last revision (which causes a parsing failure)