### PR TITLE
Fix for prompt_toolkit dependency incompatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 jupyter
 requests
+ipython<6.5


### PR DESCRIPTION
When doing a fresh setup of pb-exercises, I’m seeing a problem with jupyter. It isn’t able to print ‘hello world’. This appears to be related to an incompatibility of IPython 7.0.1 and jupyter-console which depend on different versions of prompt_toolkit 
See https://github.com/jupyter/jupyter_console/issues/158
This is a temporary fix for the problem, which can be removed once the jupyter issue is resolved.